### PR TITLE
Migrate to TypeScript

### DIFF
--- a/Middleware.ts
+++ b/Middleware.ts
@@ -1,4 +1,4 @@
-module.exports = (isOnSpamWatch) => {
+export default (isOnSpamWatch) => {
   return async (ctx, next) => {
     if (await isOnSpamWatch(ctx.from.id)) {
       console.log(`User ${ctx.from.id} is banned on SpamWatch. Blocking command.`);

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # TelegramBot-SpamWatch
+
+[![GitHub License](https://img.shields.io/github/license/abocn/TelegramBot)](https://github.com/abocn/TelegramBot/blob/main/LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org)
+
 Kowalski integration with the SpamWatch API (WIP)

--- a/spamwatch.ts
+++ b/spamwatch.ts
@@ -1,9 +1,9 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
 const blocklistPath = path.join(__dirname, 'sw_blocklist.txt');
 
-let blocklist = [];
+let blocklist: string[] = [];
 
 const readBlocklist = () => {
   try {
@@ -19,10 +19,10 @@ const readBlocklist = () => {
   }
 };
 
-const isOnSpamWatch = (userId) => {
-  return blocklist.includes(String(userId));
+const isOnSpamWatch = (userId: string) => {
+  return blocklist.includes(userId);
 };
 
 readBlocklist();
 
-module.exports = { isOnSpamWatch };
+export { isOnSpamWatch };


### PR DESCRIPTION
In conjunction with the main updates to the `TelegramBot` repo, this component must be migrated to TypeScript in order for the SpamWatch integration to work in the bot.